### PR TITLE
Avoid allocations for opaque values

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -285,6 +285,13 @@ func (sd *sliceDecoder) decode(d *decodeState, v reflect.Value, opts fieldOption
 		panic(fmt.Errorf("Not enough data to read elements"))
 	}
 
+	// For opaque values, we can return a reference instead of making a new slice
+	if v.Elem().Type().Elem().Kind() == reflect.Uint8 {
+		v.Elem().Set(reflect.ValueOf(elemData))
+		return read + length
+	}
+
+	// For other values, we need to decode the raw data
 	elemBuf := &decodeState{}
 	elemBuf.Write(elemData)
 	elems := []reflect.Value{}

--- a/decode.go
+++ b/decode.go
@@ -79,6 +79,7 @@ func typeDecoder(t reflect.Type) decoderFunc {
 
 var (
 	unmarshalerType = reflect.TypeOf(new(Unmarshaler)).Elem()
+	uint8Type       = reflect.TypeOf(uint8(0))
 )
 
 func newTypeDecoder(t reflect.Type) decoderFunc {
@@ -297,7 +298,7 @@ func (sd *sliceDecoder) decode(d *decodeState, v reflect.Value, opts fieldOption
 	}
 
 	// For opaque values, we can return a reference instead of making a new slice
-	if v.Elem().Type().Elem().Kind() == reflect.Uint8 {
+	if v.Elem().Type().Elem() == uint8Type {
 		v.Elem().Set(reflect.ValueOf(elemData))
 		return read + length
 	}


### PR DESCRIPTION
Many structures used in cryptographic protocols use a lot of opaque values.  In the current decoding process, each opaque value results in a new `[]uint8` being allocated, which makes things quite slow.  This PR changes the decoder so that when the value being decoded is of type `[]uint8`, we simply return a slice that references the input data, rather than making a copy.

This raises the risk of conflict because we will have multiple slices pointing to the same buffer.  Such conflict seems unlikely in common cases, where a buffer is only used once, for decoding, and then the unmarshaled object is used.  (It could lead to increased memory usage in such cases, depending on whether the GC figures out to free unused parts of the buffer.) 

It does succeed in speeding things up.  From a quick benchmark test on something that looks a bit like a large MLS Welcome message (code below), we get about an order of magnitude increase in decoding speed.

```
AFTER:  BenchmarkOpaque-4         888      1447710 ns/op
BEFORE: BenchmarkOpaque-4          61     19005075 ns/op
```

Code for benchmark:

```
package syntax

import (
	"crypto/rand"
	"testing"

	"github.com/stretchr/testify/require"
)

type Bytes1 struct {
	Data []byte `tls:"head=1"`
}

type Array struct {
	Data []Bytes1 `tls:"head=4"`
}

func BenchmarkOpaque(b *testing.B) {
	original := Array{Data: make([]Bytes1, 5000)}
	for i := range original.Data {
		original.Data[i] = Bytes1{Data: make([]byte, 32)}
		rand.Read(original.Data[i].Data)
	}

	marshaled, err := Marshal(original)
	require.Nil(b, err)

	b.ResetTimer()

	for i := 0; i < b.N; i++ {
		unmarshaled := Array{}
		_, err := Unmarshal(marshaled, &unmarshaled)
		require.Nil(b, err)
	}
}
```