### PR TITLE
Don't allocate new heap for uints

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -200,11 +200,9 @@ func writeVarint(e *encodeState, u uint64) {
 }
 
 func writeUint(e *encodeState, u uint64, len int) {
-	data := make([]byte, len)
 	for i := 0; i < len; i += 1 {
-		data[i] = byte(u >> uint(8*(len-i-1)))
+		e.WriteByte(byte(u >> uint(8*(len-i-1))))
 	}
-	e.Write(data)
 }
 
 //////////


### PR DESCRIPTION
In my local testing, the gains here look significant.  For encoding a 1000x1000 array of uint8:

```
Before: BenchmarkEncode-4   	     160	   7060387 ns/op
After:  BenchmarkEncode-4   	     310	   3847216 ns/op
```